### PR TITLE
feat: improve annotation workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ downloads/
 eggs/
 .eggs/
 lib/
+!src/lib/
 lib64/
 parts/
 sdist/

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ['@babel/preset-env', '@babel/preset-react'],
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  moduleNameMapper: {
+    '\\.(css)$': 'identity-obj-proxy'
+  },
+  transform: {
+    '^.+\\.[tj]sx?$': 'babel-jest'
+  }
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "webpack --mode production",
     "build:dev": "webpack --mode development",
     "build:watch": "webpack --mode development --watch",
-    "start": "webpack serve --mode development"
+    "start": "webpack serve --mode development",
+    "test": "jest"
   },
   "dependencies": {
     "react": "^17.0.0",
@@ -19,8 +20,13 @@
     "@babel/preset-env": "^7.12.0",
     "@babel/preset-react": "^7.12.0",
     "babel-loader": "^8.2.0",
+    "babel-jest": "^29.0.0",
     "css-loader": "^6.0.0",
     "style-loader": "^3.0.0",
+    "jest": "^29.0.0",
+    "react-test-renderer": "^17.0.0",
+    "identity-obj-proxy": "^3.0.0",
+    "jest-environment-jsdom": "^29.0.0",
     "webpack": "^5.0.0",
     "webpack-cli": "^4.0.0",
     "webpack-dev-server": "^4.0.0"

--- a/src/lib/components/NERLabeler.css
+++ b/src/lib/components/NERLabeler.css
@@ -80,140 +80,16 @@
     border-radius: 6px;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
     z-index: 1000;
+    padding: 8px;
 }
 
-.ner-modal-content {
-    padding: 15px;
-    min-width: 200px;
-}
-
-.ner-modal-content h4 {
-    margin: 0 0 10px 0;
-    font-size: 14px;
-    color: #333;
-}
-
-.ner-label-btn {
-    display: block;
-    width: 100%;
-    padding: 8px 12px;
-    margin: 4px 0;
-    border: 1px solid #ddd;
+.ner-label-select {
+    padding: 6px 8px;
+    border: 1px solid #ccc;
     border-radius: 4px;
     background: white;
-    cursor: pointer;
-    font-size: 13px;
-    transition: all 0.2s ease;
-}
-
-.ner-label-btn:hover {
-    background-color: #f5f5f5;
-    transform: translateY(-1px);
-}
-
-.ner-label-btn.ner-person {
-    background-color: #ffeb3b;
-    border-color: #fbc02d;
-}
-
-.ner-label-btn.ner-organization {
-    background-color: #2196f3;
-    color: white;
-    border-color: #1976d2;
-}
-
-.ner-label-btn.ner-location {
-    background-color: #4caf50;
-    color: white;
-    border-color: #388e3c;
-}
-
-.ner-label-btn.ner-miscellaneous {
-    background-color: #ff9800;
-    color: white;
-    border-color: #f57c00;
-}
-
-.ner-cancel-btn {
-    display: block;
-    width: 100%;
-    padding: 8px 12px;
-    margin: 8px 0 0 0;
-    border: 1px solid #dc3545;
-    border-radius: 4px;
-    background: white;
-    color: #dc3545;
-    cursor: pointer;
-    font-size: 13px;
-    transition: all 0.2s ease;
-}
-
-.ner-cancel-btn:hover {
-    background-color: #dc3545;
-    color: white;
-}
-
-.ner-entities-summary {
-    margin-top: 20px;
-    padding: 15px;
-    background-color: #f8f9fa;
-    border: 1px solid #dee2e6;
-    border-radius: 6px;
-}
-
-.ner-entities-summary h4 {
-    margin: 0 0 10px 0;
-    color: #495057;
-    font-size: 16px;
-}
-
-.ner-entities-list {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
-}
-
-.ner-entity-item {
-    display: flex;
-    align-items: center;
-    background: white;
-    border: 1px solid #dee2e6;
-    border-radius: 20px;
-    padding: 6px 10px;
     font-size: 14px;
-}
-
-.ner-entity-label {
-    padding: 2px 8px;
-    border-radius: 12px;
-    font-size: 11px;
-    font-weight: bold;
-    text-transform: uppercase;
-    margin-right: 8px;
-}
-
-.ner-entity-text {
-    margin-right: 8px;
-    color: #495057;
-}
-
-.ner-remove-btn {
-    background: #dc3545;
-    color: white;
-    border: none;
-    border-radius: 50%;
-    width: 20px;
-    height: 20px;
-    cursor: pointer;
-    font-size: 12px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: background-color 0.2s ease;
-}
-
-.ner-remove-btn:hover {
-    background: #c82333;
+    min-width: 160px;
 }
 
 /* Responsive design */
@@ -222,13 +98,8 @@
         padding: 15px;
         font-size: 14px;
     }
-    
+
     .ner-label-modal {
         max-width: 90vw;
-    }
-    
-    .ner-entities-list {
-        flex-direction: column;
-        gap: 4px;
     }
 }

--- a/src/lib/components/NERLabeler.test.js
+++ b/src/lib/components/NERLabeler.test.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import NERLabeler from './NERLabeler.react';
+
+test('adds entity on label selection', () => {
+  const mockSetProps = jest.fn();
+  const component = renderer.create(<NERLabeler text="Hello world" setProps={mockSetProps} />);
+  const instance = component.getInstance();
+  act(() => {
+    instance.setState({
+      selectedText: 'Hello',
+      selectedRange: { startOffset: 0, endOffset: 5 }
+    });
+  });
+  act(() => {
+    instance.handleLabelSelection('PERSON');
+  });
+  expect(mockSetProps).toHaveBeenCalledWith({
+    entities: expect.arrayContaining([
+      expect.objectContaining({
+        text: 'Hello',
+        label: 'PERSON',
+        start: 0,
+        end: 5
+      })
+    ])
+  });
+});
+
+test('double click removes entity', () => {
+  const mockSetProps = jest.fn();
+  const entities = [{ id: 1, text: 'Hello', label: 'PERSON', start: 0, end: 5 }];
+  const component = renderer.create(
+    <NERLabeler text="Hello world" entities={entities} setProps={mockSetProps} />
+  );
+  const span = component.root.findByProps({ className: 'ner-entity ner-person' });
+  act(() => span.props.onDoubleClick({ stopPropagation: () => {} }));
+  expect(mockSetProps).toHaveBeenCalledWith({ entities: [] });
+});


### PR DESCRIPTION
## Summary
- replace label buttons with compact context-menu dropdown
- allow removing entities by double-click
- add unit tests and Jest setup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896a76d06508332bb2e2fe7612f281e