### PR TITLE
Improve annotation labeler with dropdown selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
+/lib/
 lib64/
 parts/
 sdist/

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ['@babel/preset-env', '@babel/preset-react'],
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "webpack --mode production",
     "build:dev": "webpack --mode development",
     "build:watch": "webpack --mode development --watch",
-    "start": "webpack serve --mode development"
+    "start": "webpack serve --mode development",
+    "test": "jest"
   },
   "dependencies": {
     "react": "^17.0.0",
@@ -18,12 +19,27 @@
     "@babel/core": "^7.12.0",
     "@babel/preset-env": "^7.12.0",
     "@babel/preset-react": "^7.12.0",
+    "@testing-library/jest-dom": "^5.16.5",
+    "@testing-library/react": "^12.1.5",
+    "babel-jest": "^29.7.0",
     "babel-loader": "^8.2.0",
     "css-loader": "^6.0.0",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
+    "identity-obj-proxy": "^3.0.0",
     "style-loader": "^3.0.0",
     "webpack": "^5.0.0",
     "webpack-cli": "^4.0.0",
     "webpack-dev-server": "^4.0.0"
+  },
+  "jest": {
+    "testEnvironment": "jsdom",
+    "transform": {
+      "^.+\\.[tj]sx?$": "babel-jest"
+    },
+    "moduleNameMapper": {
+      "\\.(css|less|scss)$": "identity-obj-proxy"
+    }
   },
   "files": [
     "build/*",

--- a/src/lib/components/NERLabeler.css
+++ b/src/lib/components/NERLabeler.css
@@ -4,8 +4,8 @@
 }
 
 .ner-text-container {
-    background-color: #f8f9fa;
-    border: 1px solid #dee2e6;
+    background-color: #ffffff;
+    border: 1px solid #ced4da;
     border-radius: 6px;
     padding: 20px;
     line-height: 1.6;
@@ -13,6 +13,7 @@
     min-height: 200px;
     cursor: text;
     position: relative;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
 }
 
 .ner-entity {
@@ -48,6 +49,19 @@
 
 .ner-entity:hover .ner-label-badge {
     opacity: 1;
+}
+
+.ner-label-dropdown {
+    position: absolute;
+    z-index: 1000;
+}
+
+.ner-label-dropdown select {
+    padding: 6px 8px;
+    font-size: 14px;
+    border: 1px solid #ced4da;
+    border-radius: 4px;
+    background-color: #fff;
 }
 
 /* Entity type colors */

--- a/src/lib/components/__tests__/NERLabeler.test.js
+++ b/src/lib/components/__tests__/NERLabeler.test.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import {render, fireEvent} from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import NERLabeler from '../NERLabeler.react';
+
+test('double clicking an entity removes it', () => {
+  const mockSetProps = jest.fn();
+  const entity = {id: 1, text: 'John', label: 'PERSON', start: 0, end: 4};
+  const {getByText} = render(
+    <NERLabeler text="John went home" entities={[entity]} setProps={mockSetProps} />
+  );
+  const span = getByText('John');
+  fireEvent.doubleClick(span);
+  expect(mockSetProps).toHaveBeenCalledWith({entities: []});
+});


### PR DESCRIPTION
## Summary
- show label options in a context-menu dropdown on right-click
- remove entities on click or double-click and drop bottom summary panel
- add Jest unit test for entity removal and configure testing

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896a76d06508332bb2e2fe7612f281e